### PR TITLE
openssl: Add option to disable apps build

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -32,6 +32,7 @@ class OpenSSLConan(ConanFile):
         "capieng_dialog": [True, False],
         "enable_capieng": [True, False],
         "no_aria": [True, False],
+        "no_apps": [True, False],
         "no_autoload_config": [True, False],
         "no_asm": [True, False],
         "no_async": [True, False],


### PR DESCRIPTION
This is useful for example to disable build of http_server for tvOS.

tvOS doesn't have fork() and http_server uses it:

apps/lib/http_server.c:156:24: error: 'fork' is unavailable: not available on tvOS
        switch (fpid = fork()) {

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
